### PR TITLE
Validate config. Ensure Labyrinth is not Manual Control

### DIFF
--- a/scripts/ShadowRift.ash
+++ b/scripts/ShadowRift.ash
@@ -27,122 +27,160 @@ import <vprops.ash>;
 
 // What is our quest goal?
 //
-// artifact		Easiest.
-//			10 combats with normal shadow creatures; mundane shadow item
-//			non-combat offers a choice for the artifact.
-// entity		Most profitable, but hardest.
-//			10 combats with normal shadow creatures
-//			non-combat replaced by shadow boss, with combat powers
-//			Each boss always drops two specific mundane shadow items
-// items		10 combats with normal shadow creatures.
-//			non-combat offers buffs or stats
-//			costs 3 of a specific mundane shadow item
+// artifact             Easiest.
+//                      10 combats with normal shadow creatures; mundane shadow item
+//                      non-combat offers a choice for the artifact.
+// entity               Most profitable, but hardest.
+//                      10 combats with normal shadow creatures
+//                      non-combat replaced by shadow boss, with combat powers
+//                      Each boss always drops two specific mundane shadow items
+// items                10 combats with normal shadow creatures.
+//                      non-combat offers buffs or stats
+//                      costs 3 of a specific mundane shadow item
 
 string quest_goal = define_property( "VSR.QuestGoal", "string", "artifact" );
 
 // If we seek items, the Shadow Labyrinth will give us a buff or stats.
 // Which one do you want?
 //
-// muscle		90-100 Muscle substats
-// mysticality		90-100 Mysticality substats
-// moxie		90-100 Moxie substats
-// effects		+3 turns to 3 random effects
-// maxHP		30 Shadow's Heart: Maximum HP +300%
-// maxMP		30 Shadow's Chill: Maximum MP +300
-// resistance		30 Shadow's Thickness: +5 Spooky, Hot, Sleaze resistance
+// muscle               90-100 Muscle substats
+// mysticality          90-100 Mysticality substats
+// moxie                90-100 Moxie substats
+// effects              +3 turns to 3 random effects
+// maxHP                30 Shadow's Heart: Maximum HP +300%
+// maxMP                30 Shadow's Chill: Maximum MP +300
+// resistance           30 Shadow's Thickness: +5 Spooky, Hot, Sleaze resistance
 
 string labyrinth_goal = define_property( "VSR.LabyrinthGoal", "string", "maxHP" );
 
 // What is our quest reward?
 //
-// forge		Opens Shadow Forge until you use an adventure.
-//			You can craft special shadow items from mundane shadow items.
-// waters		30 turns of Shadow Waters:
-//			Initiative: +100, Item Drop: +100, Meat Drop: +200, Combat Rate: -10
-// forest		(Once per day) 2-3 each of the 3 mundane items from the
-//			specific ingress you used to enter the Shadow Rift
+// forge                Opens Shadow Forge until you use an adventure.
+//                      You can craft special shadow items from mundane shadow items.
+// waters               30 turns of Shadow Waters:
+//                      Initiative: +100, Item Drop: +100, Meat Drop: +200, Combat Rate: -10
+// forest               (Once per day) 2-3 each of the 3 mundane items from the
+//                      specific ingress you used to enter the Shadow Rift
 
 // Default is "forest" (or "waters" if already looted forest today).
 string quest_reward = define_property( "VSR.QuestReward", "string", "forest" );
 
 // Which shadow rift ingress to use?
 //
-// desertbeach		shadow flame	shadow fluid	shadow sinew
-// forestvillage	shadow bread	shadow ice	shadow venom
-// mclargehuge		shadow skin	shadow ice	shadow stick
-// beanstalk		shadow fluid	shadow glass	shadow nectar
-// manor3		shadow sausage	shadow flame	shadow venom
-// 8bit			shadow ice	shadow fluid	shadow glass
-// pyramid		shadow sausage	shadow brick	shadow sinew
-// giantcastle		shadow sausage	shadow bread	shadow fluid
-// woods		shadow flame	shadow nectar	shadow stick
-// hiddencity		shadow brick	shadow sinew	shadow nectar
-// cemetery		shadow bread	shadow brick	shadow stick
-// plains		shadow sausage	shadow skin	shadow venom
-// town_right		shadow skin	shadow bread	shadow glass
+// desertbeach          shadow flame    shadow fluid    shadow sinew
+// forestvillage        shadow bread    shadow ice      shadow venom
+// mclargehuge          shadow skin     shadow ice      shadow stick
+// beanstalk            shadow fluid    shadow glass    shadow nectar
+// manor3               shadow sausage  shadow flame    shadow venom
+// 8bit                 shadow ice      shadow fluid    shadow glass
+// pyramid              shadow sausage  shadow brick    shadow sinew
+// giantcastle          shadow sausage  shadow bread    shadow fluid
+// woods                shadow flame    shadow nectar   shadow stick
+// hiddencity           shadow brick    shadow sinew    shadow nectar
+// cemetery             shadow bread    shadow brick    shadow stick
+// plains               shadow sausage  shadow skin     shadow venom
+// town_right           shadow skin     shadow bread    shadow glass
 //
-// random		Pick one at random from the 13 possible
-//			If looking for "items", pick one that has that mundane item.
+// random               Pick one at random from the 13 possible
+//                      If looking for "items", pick one that has that mundane item.
 
 string rift_ingress = define_property( "VSR.RiftIngress", "string", "random" );
 
-static string[string] rift_name = {
-    "desertbeach" : "Shadow Rift (Desert Beach)",
-    "forestvillage" : "Shadow Rift (Forest Village)",
-    "mclargehuge" : "Shadow Rift (Mt. McLargeHuge)",
-    "beanstalk" : "Shadow Rift (Somewhere Over the Beanstalk)",
-    "manor3" : "Shadow Rift (Spookyraven Manor Third Floor)",
-    "8bit" : "Shadow Rift (The 8-Bit Realm)",
-    "pyramid" : "Shadow Rift (The Ancient Buried Pyramid)",
-    "giantcastle" : "Shadow Rift (The Castle in the Clouds in the Sky)",
-    "woods" : "Shadow Rift (The Distant Woods)",
-    "hiddencity" : "Shadow Rift (The Hidden City)",
-    "cemetery" : "Shadow Rift (The Misspelled Cemetary)",
-    "plains" : "Shadow Rift (The Nearby Plains)",
-    "town_right" : "Shadow Rift (The Right Side of the Tracks)",
+// ***************************
+// *     Shadow Rifts        *
+// ***************************
 
-    "random" : "(a random ingress)"
+record ShadowRift {
+    string ingress;	// Keyword for ingress (as saved in "shadowRiftIngress"
+    location loc;	// The location-via-ingress to adventure in
+    item[3] items;	// The items you can find through this ingress
 };
 
-static location[int] all_rifts = {
-    0 : $location[ Shadow Rift (Desert Beach)],
-    1 : $location[ Shadow Rift (Forest Village)],
-    2 : $location[ Shadow Rift (Mt. McLargeHuge)],
-    3 : $location[ Shadow Rift (Somewhere Over the Beanstalk)],
-    4 : $location[ Shadow Rift (Spookyraven Manor Third Floor)],
-    5 : $location[ Shadow Rift (The 8-Bit Realm)],
-    6 : $location[ Shadow Rift (The Ancient Buried Pyramid)],
-    7 : $location[ Shadow Rift (The Castle in the Clouds in the Sky)],
-    8 : $location[ Shadow Rift (The Distant Woods)],
-    9 : $location[ Shadow Rift (The Hidden City)],
-    10 : $location[ Shadow Rift (The Misspelled Cemetary)],
-    11 : $location[ Shadow Rift (The Nearby Plains)],
-    12 : $location[ Shadow Rift (The Right Side of the Tracks)],
-};
+typedef ShadowRift[int] ShadowRiftArray;
 
-location ingress_to_location(string ingress)
+static ShadowRift[string] ingress_to_rift;
+static ShadowRiftArray[item] item_to_rifts;
+
+ShadowRift makeShadowRift(string ingress, string container, string... types)
 {
-    if (ingress == "random") {
-	return all_rifts[random(count(all_rifts))];
+    if (count(types) != 3) {
+	abort("ShadowRift(" + ingress +") has " + count(types) + " items.");
     }
-    return rift_name[ingress].to_location();
+
+    location loc = to_location("Shadow Rift (" + container + ")");
+    item[] items = {
+	to_item("shadow " + types[0]),
+	to_item("shadow " + types[1]),
+	to_item("shadow " + types[2]),
+    };
+
+    ShadowRift rift = new ShadowRift(ingress, loc, items);
+
+    // Add to maps:
+    ingress_to_rift[ingress] = rift;
+
+    // Add to map: item -> ShadowRiftArray
+    foreach n, it in items {
+	ShadowRiftArray array = item_to_rifts[it];
+	array[count(array)] = rift;
+    }
+
+    return rift;
 }
 
-static string[location] rift_items = {
-    $location[ Shadow Rift (The 8-Bit Realm)] : "shadow ice, shadow fluid, shadow glass",
-    $location[ Shadow Rift (Desert Beach)] : "shadow flame, shadow fluid, shadow sinew",
-    $location[ Shadow Rift (Somewhere Over the Beanstalk)] : "shadow fluid, shadow glass, shadow nectar",
-    $location[ Shadow Rift (The Castle in the Clouds in the Sky)] : "shadow sausage, shadow bread, shadow fluid",
-    $location[ Shadow Rift (The Misspelled Cemetary)] : "shadow bread, shadow brick, shadow stick",
-    $location[ Shadow Rift (The Hidden City)] : "shadow brick, shadow sinew, shadow nectar",
-    $location[ Shadow Rift (Mt. McLargeHuge)] : "shadow skin, shadow ice, shadow stick",
-    $location[ Shadow Rift (The Nearby Plains)] : "shadow sausage, shadow skin, shadow venom",
-    $location[ Shadow Rift (The Ancient Buried Pyramid)] : "shadow sausage, shadow brick, shadow sinew",
-    $location[ Shadow Rift (Spookyraven Manor Third Floor)] : "shadow sausage, shadow flame, shadow venom",
-    $location[ Shadow Rift (The Right Side of the Tracks)] : "shadow skin, shadow bread, shadow glass",
-    $location[ Shadow Rift (Forest Village)] : "shadow bread, shadow ice, shadow venom",
-    $location[ Shadow Rift (The Distant Woods)] : "shadow flame, shadow nectar, shadow stick",
+static ShadowRift[] allRifts = {
+    // These are sorted by container name. Not that it matters.
+    makeShadowRift("desertbeach", "Desert Beach", "flame", "fluid", "sinew"),
+    makeShadowRift("forestvillage", "Forest Village", "bread", "ice", "venom"),
+    makeShadowRift("mclargehuge", "Mt. McLargeHuge", "skin", "ice", "stick"),
+    makeShadowRift("beanstalk", "Somewhere Over the Beanstalk", "fluid", "glass", "nectar"),
+    makeShadowRift("manor3", "Spookyraven Manor Third Floor", "sausage", "flame", "venom"),
+    makeShadowRift("8bit", "The 8-Bit Realm", "ice", "fluid", "glass"),
+    makeShadowRift("pyramid", "The Ancient Buried Pyramid", "sausage", "brick", "sinew"),
+    makeShadowRift("giantcastle", "The Castle in the Clouds in the Sky", "sausage", "bread", "fluid"),
+    makeShadowRift("woods", "The Distant Woods", "flame", "nectar", "stick"),
+    makeShadowRift("hiddencity", "The Hidden City", "brick", "sinew", "nectar"),
+    makeShadowRift("cemetery", "The Misspelled Cemetary", "bread", "brick", "stick"),
+    makeShadowRift("plains", "The Nearby Plains", "sausage", "skin", "venom"),
+    makeShadowRift("town_right", "The Right Side of the Tracks", "skin", "bread", "glass"),
 };
+
+string rift_name(string ingress)
+{
+    if (ingress == "random") {
+	return "(a random ingress)";
+    }
+    if (ingress_to_rift contains ingress) {
+	return ingress_to_rift[ingress].loc.to_string();
+    }
+    // An abort is harsh, but validation should have eliminated this.
+    abort("Ingress '" + ingress + "' is unknown");
+    // Really, ASH?
+    exit;
+}
+
+ShadowRift ingress_to_rift(string ingress)
+{
+    if (ingress == "random") {
+	return allRifts[random(count(allRifts))];
+    }
+    if (ingress_to_rift contains ingress) {
+	ingress_to_rift[ingress];
+    }
+    // An abort is harsh, but validation should have eliminated this.
+    abort("Ingress '" + ingress + "' is unknown");
+    // Really, ASH?
+    exit;
+}
+
+string rift_items(ShadowRift rift)
+{
+    return rift.items[0] + ", " + rift.items[1] + ", " + rift.items[2];
+}
+
+// ***************************
+// *      Constants          *
+// ***************************
 
 static item PAY_PHONE = $item[closed-circuit pay phone];
 static item SHADOW_LODESTONE = $item[Rufus's shadow lodestone];
@@ -162,10 +200,77 @@ static int[string] reward_option = {
     "forest": 3,
 };
 
+// ***************************
+// *      Validation         *
+// ***************************
+
+static string_set quest_goal_options = $strings[
+    artifact,
+    entity,
+    items
+];
+
+static string_set labyrinth_goal_options = $strings[
+    muscle,
+    mysticality,
+    moxie,
+    effects,
+    maxHP,
+    maxMP,
+    resistance
+];
+
+static string_set quest_reward_options = $strings[
+    forge,
+    waters,
+    forest
+];
+
+void validate_configuration()
+{
+    boolean valid = true;
+
+    print( "Validating configuration..." );
+
+    if ( !( quest_goal_options contains quest_goal ) ) {
+	print( "VSR.QuestGoal: '" + quest_goal + "' is invalid.", "red" );
+	valid = false;
+    }
+
+    if ( !( labyrinth_goal_options contains labyrinth_goal ) ) {
+	print( "VSR.LabyrinthGoal: '" + labyrinth_goal + "' is invalid.", "red" );
+	valid = false;
+    }
+
+    if ( !( quest_reward_options contains quest_reward ) ) {
+	print( "VSR.QuestReward: '" + quest_goal + "' is invalid.", "red" );
+	valid = false;
+    }
+
+    if ( ( rift_ingress != "random" ) &&
+	 !( ingress_to_rift contains rift_ingress ) ) {
+	print( "VSR.RiftIngress: '" + rift_ingress + "' is invalid.", "red" );
+	valid = false;
+    }
+
+    if ( !valid ) {
+	abort( "Correct those errors and try again." );
+    }
+
+    print( "All is well!" );
+}
+
+// ***************************
+// *      Action          *
+// ***************************
+
 void main(string parameters)
 {
     void parse_parameters()
     {
+	print();
+	print( "Checking arguments...." );
+
 	foreach n, keyword in parameters.split_string(" ") {
 	    switch (keyword) {
 	    case "artifact":
@@ -211,27 +316,44 @@ void main(string parameters)
 		abort("Unrecognized keyword: " + keyword);
 	    }
 	}
+	print( "Cool, cool." );
     }
 
+    void check_quest_state()
+    {
+	print();
+	print( "Checking quest state...." );
+
+	if (get_property("questRufus") != "unstarted") {
+	    abort("You are already on a quest for Rufus: " +
+		  get_property("rufusQuestType") +
+		  " -> " +
+		  get_property("rufusQuestTarget"));
+	}
+
+	if (get_property("_shadowAffinityToday").to_boolean() &&
+	    !user_confirm("You have already gained Shadow Affinity today, so this will take turns. Are you sure?")) {
+	    exit;
+	}
+
+	int lodestones = item_amount(SHADOW_LODESTONE);
+	if (lodestones > 0 ) {
+	    abort("You already have " + lodestones + " shadow lodestones in inventory.");
+	}
+
+	print( "Clean. Ready to go!" );
+    }
+
+    // Check initial configuration
+    validate_configuration();
+
+    // Parse parameters and override configuration
     parse_parameters();
 
-    if (get_property("questRufus") != "unstarted") {
-	abort("You are already on a quest for Rufus: " +
-	      get_property("rufusQuestType") +
-	      " -> " +
-	      get_property("rufusQuestTarget"));
-    }
+    // Check quest state to ensure we can handle this
+    check_quest_state();
 
-    if (get_property("_shadowAffinityToday").to_boolean() &&
-	!user_confirm("You have already gained Shadow Affinity today, so this will take turns. Are you sure?")) {
-	exit;
-    }
-
-    int lodestones = item_amount(SHADOW_LODESTONE);
-    if (lodestones > 0 ) {
-	abort("You already have " + lodestones + " shadow lodestones in inventory.");
-    }
-
+    print();
     print("You want to accept an " + quest_goal + " quest from Rufus.");
     print("You want the '" + quest_reward + "' reward for accomplishing that.");
     if (quest_goal == "items") {
@@ -240,43 +362,23 @@ void main(string parameters)
     if (quest_reward == "forest" && get_property("_shadowForestLooted").to_boolean()) {
 	print("(You have already looted the forest today, so instead, you will get Shadow Waters.)");
     }
-    print("You want to enter " + rift_name[rift_ingress] + ".");
+
+    print("You want to enter " + rift_name(rift_ingress) + ".");
 
     // Choose the rift you will actually enter.
-    location rift = ingress_to_location(rift_ingress);
+    ShadowRift rift = ingress_to_rift(rift_ingress);
     if (rift_ingress == "random") {
-	print("We chose " + rift.to_string() + " for you.");
+	print("We chose " + rift.loc.to_string() + " for you.");
     }
-    print("You will find the following items there: " + rift_items[rift]);
+    print("You will find the following items there: " + rift_items(rift));
 
     // If the goal is "entity", the boss replaces the Shadow Labyrinth.
     // If the goal is "artifact", automation will find it in the Shadow Labyrinth.
-    // Only if the goal is "items" does the user's desire matter.
-    if (quest_goal == "items") {
+    // If the goal is "items", automation will find the desired goal in the Shadow Labyrinth.
+    // KoLmafia will not automate if the shadowLabyrinthGoal is "Manual Control".
+    // So, set it for either "artifact" or "items".
+    if (quest_goal == "artifact" || quest_goal == "items") {
 	set_property("shadowLabyrinthGoal", labyrinth_goal);
-    }
-
-    void collect_reward()
-    {
-	string page = visit_url( SHADOW_RIFT.to_url() );
-	if ( page.contains_text( "choice.php" ) ) {
-	    int option = reward_option[quest_reward];
-	    // You can only get the forest once per day.
-	    if (!(available_choice_options() contains option)) {
-		option = 2;
-	    }
-	    run_choice(option);
-	    return;
-	}
-
-	// Say what? You have a shadow lodestone.
-	if ( page.contains_text( "fight.php" ) ) {
-	    // Your CCS had better be set up to handle this!
-	    run_combat();
-	    return;
-	}
-	// What is this?
-	abort("What happened?");
     }
 
     // Accept a quest from Rufus.
@@ -292,7 +394,7 @@ void main(string parameters)
 	// adventures do not need it, so restore item drop outfit.
 	try {
 	    cli_execute( "checkpoint" );
-	    adv1(rift, 0);
+	    adv1(rift.loc, 0);
 	} finally {
 	    cli_execute( "outfit checkpoint" );
 	}
@@ -346,9 +448,32 @@ void main(string parameters)
     run_choice(1);
 
     // You should now have Rufus's shadow lodestone
-    lodestones = item_amount(SHADOW_LODESTONE);
+    int lodestones = item_amount(SHADOW_LODESTONE);
     if (lodestones == 0 ) {
 	abort("You didn't get a shadow lodestone!");
+    }
+
+    void collect_reward()
+    {
+	string page = visit_url( SHADOW_RIFT.to_url() );
+	if ( page.contains_text( "choice.php" ) ) {
+	    int option = reward_option[quest_reward];
+	    // You can only get the forest once per day.
+	    if (!(available_choice_options() contains option)) {
+		option = 2;
+	    }
+	    run_choice(option);
+	    return;
+	}
+
+	// Say what? You have a shadow lodestone.
+	if ( page.contains_text( "fight.php" ) ) {
+	    // Your CCS had better be set up to handle this!
+	    run_combat();
+	    return;
+	}
+	// What is this?
+	abort("What happened?");
     }
 
     // Adventure once more to collect your reward


### PR DESCRIPTION
1) Refactor to have a ShadowRift record per ingress.
2) Validate configuration
3) Bug reported by Magus_Prime: if the Shadow Labyrinth choice is set to Manual Control, KoLmafia does not automate it.
Duh. Since both "items" and "artifact" expect it to be automated, set shadowLabyrinthGoal for both cases.