### PR TITLE
Add support for Jurassic Parka

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Here are the configuration properties.
 | ```VSR.ChosenFamiliar``` | (familiar) or none | none | If not "none", which familiar to bring with you
 | ```VSR.ExtraMaximizerParameters``` | (string) | "" | Extra parameters to usewhen maximizing for item drop
 | ```VSR.UseShadowRiftConsult``` | true or false | true | Whether to automatically use ShadowRiftConsult for combats
+| ```VSR.UseJurassicParka``` | (string) | both | Whether to equip a Jurassic Parka before combats
 | ```VSR.UseSpaceTouristPhaser``` | true or false | false | Whether to acquire and equip Space Tourist Phaser for use in combats
 | ```VSR.CastSteelyEyedSquint``` | true or false | true | Whether to cast Steely-eyed Squint before free-only combats
 | ```VSR.CastBendHell``` | true or false | true | Whether to cast Bend Hell before free-only combats

--- a/scripts/ShadowRift.ash
+++ b/scripts/ShadowRift.ash
@@ -162,7 +162,7 @@ boolean use_space_tourist_phaser = define_property( "VSR.UseSpaceTouristPhaser",
 // both                 Use spikolodon mode for normal shadow monsters
 //                      and kachungasaur mode for shadow bosses.
 
-string use_jurassic_parka = define_property( "VSR.UseJurassicParka", "string", "both" );
+string parka_mode = define_property( "VSR.UseJurassicParka", "string", "both" );
 
 // Should we cast Steely-Eyed Squint to double item drops from shadow monster combats?
 //
@@ -393,8 +393,8 @@ void validate_configuration()
 	valid = false;
     }
 
-    if ( !( parka_options contains use_jurassic_parka ) ) {
-	print( "VSR.UseJurassicParka: '" + use_jurassic_parka + "' is invalid.", "red" );
+    if ( !( parka_options contains parka_mode ) ) {
+	print( "VSR.UseJurassicParka: '" + parka_mode + "' is invalid.", "red" );
 	valid = false;
     }
 
@@ -429,7 +429,7 @@ if (overdrunk) {
 // We can equip a Jurassic Parka only if we actually own one.
 boolean have_parka = (available_amount(PARKA) > 0 && can_equip(PARKA));
 if (!have_parka) {
-    use_jurassic_parka = "none";
+    parka_mode = "none";
 }
 
 void print_help()
@@ -627,16 +627,44 @@ void parse_parameters(string parameters)
     print( "Cool, cool." );
 }
 
+int get_quest_turns()
+{
+    // It normally takes 10 turns of affinity to complete a quest:
+    // 10 shadow monster combats (each burning affinity)
+    // artifact: Shadow Labyrinth (no turns, no affinity)
+    // entity: shadow boss (no turns, burns 1 affinity)
+    //
+    // Since the labyring or boss are both free, we can visit them
+    // even if affinity had just run out.
+    int turns = 10;
+
+    // If we are using spikes, a quest requires 1 turn:
+    // 1 shadow monster combat (burning affinity)
+    // labyrinth or boss (no turns, burning 0 or 1 affinity)
+    if ( (parka_mode == "spikes" || parka_mode == "both") &&
+	 get_property("_spikolodonSpikeUses").to_int() < 5) {
+	turns = 1;
+    }
+
+    return turns;
+}
+
+int turns_until_nc()
+{
+    // How many turns to complete a quest?
+    int turns_for_quest = get_quest_turns();
+
+    // How soon will the labyrinth or boss appear? (If you burned
+    // affinity yesterday, you effectively started the quest then.)
+    int turns_until_choice = get_property("encountersUntilSRChoice").to_int();
+
+    return min(turns_for_quest, turns_until_choice);
+}
+
 boolean confirmed_free_adventures()
 {
     // If don't care if turns are free, ok
     if (!free_turns_only) {
-	return true;
-    }
-
-    // If we haven't gotten Shadow Affinity today, accepting a quest
-    // gives us 11 free turns.
-    if (!get_property("_shadowAffinityToday").to_boolean()) {
 	return true;
     }
 
@@ -650,21 +678,32 @@ boolean confirmed_free_adventures()
 	return true;
     }
 
+    // If we haven't gotten Shadow Affinity today, accepting a quest gives
+    // us 11 free turns, which is enough for an artifact or entity quest.
+    //
+    // Caveat: we cannot predict how long adventuring for items will take.
+    // Hope for the best.
+    if (!get_property("_shadowAffinityToday").to_boolean()) {
+	return true;
+    }
+
     // We already got Shadow Affinity today and we will be adventuring.
+
+    // How many turns of affinity are needed to get to the next NC?
+    int needed = turns_until_nc();
+
     // Do we have any left?
     int affinity_turns = have_effect(SHADOW_AFFINITY);
 
-    // How soon will the labyrinth or boss appear?
-    int turns_until_choice = get_property("encountersUntilSRChoice").to_int();
-
-    // Both of those encounters are free, hence ">=" rather than ">"
-    if (affinity_turns >= turns_until_choice) {
+    // A shadow boss and the Labyrinth of Shadows are both free turns,
+    // hence ">=" rather than ">"
+    if (affinity_turns >= needed) {
 	return true;
     }
 
     string message =
 	"You have " + affinity_turns + " of Shadow Affinity (and can't get any more today). " +
-	"The labyrinth or shadow boss will arrive in " + turns_until_choice + " turns. " +
+	"The labyrinth or shadow boss will arrive in " + needed + " turns. " +
 	"Are you sure you want to use non-free turns to fulfill a quest for Rufus?";
     return user_confirm(message);
 }
@@ -779,7 +818,7 @@ void prepare_for_combat()
     }
 
     // How many turns until we hit the NC?
-    int turns_until_nc = get_property("encountersUntilSRChoice").to_int();
+    int turns_until_nc = turns_until_nc();
 
     // Will we use up a turn of Shadow Affinity during our first encounter?
     int affinity_used =
@@ -842,7 +881,7 @@ void prepare_for_combat()
     }
 
     // If the user wants to wear a Jurassic Parka
-    if (use_jurassic_parka != "none") {
+    if (parka_mode != "none") {
 	expression += " +equip Jurassic Parka";
     }
 
@@ -851,11 +890,11 @@ void prepare_for_combat()
     // If we equipped a Jurassic Parka, set the desired mode
     if (have_equipped(PARKA)) {
 	string mode =
-	    use_jurassic_parka == "spikes" ?
+	    parka_mode == "spikes" ?
 	    "spikolodon" :
-	    use_jurassic_parka == "hp" ?
+	    parka_mode == "hp" ?
 	    "kachungasaur" :
-	    use_jurassic_parka == "both" ?
+	    parka_mode == "both" ?
 	    (turns_until_nc == 0 ? "kachungasaur" : "spikolodon") :
 	    "kachungasaur";
 	cli_execute("parka " + mode);
@@ -909,7 +948,7 @@ void adventure_once(ShadowRift rift)
 void prepare_for_boss()
 {
     // If we want to have Jurassic Parka in kachungasaur mode for bosses, make it so.
-    if (use_jurassic_parka == "both" & get_property("parkaMode") != "kachungasaur") {
+    if (parka_mode == "both" & get_property("parkaMode") != "kachungasaur") {
 	cli_execute("parka kachungasaur");
     }
 
@@ -1094,16 +1133,13 @@ void main(string parameters)
     print("You will find the following items there: " + rift_items(rift));
     print("After fulfilling Rufus's quest, you " + (!use_up_shadow_affinity ? "do not" : "") + " want to use up any remaining daily free fights.");
 
-    if (get_property("questRufus") == "unstarted") {
-	// Accept a quest from Rufus.
-	accept_quest();
-    }
+    void execute_quest()
+    {
+	if (get_property("questRufus") == "unstarted") {
+	    // Accept a quest from Rufus.
+	    accept_quest();
+	}
 
-    // Here follows all potential adventuring in the Shadow Rift.
-    string current_battle_action = get_property("battleAction");
-    familiar current_familiar = my_familiar();
-    cli_execute( "checkpoint" );
-    try {
 	// If we will be fighting, maximize equipment and set CCS.
 	prepare_for_combat();
 
@@ -1126,43 +1162,61 @@ void main(string parameters)
 	    abort("Could not fulfill Rufus's quest.");
 	}
 
-	// If we have left over turns of Shadow Affinity, use them up by
-	// adventuring in our selected Shadow Rift.
-	if (use_up_shadow_affinity) {
-	    // See how many turn of Shadow Affinity we have available.
-	    // Perhaps we have enough to do another quest?
-	    int affinity_turns = have_effect(SHADOW_AFFINITY);
-
-	    // Do not accept another "items" quest; we do not want to
-	    // buy items and turn them in ad infinitum.
-	    if (quest_goal != "items") {
-		while (affinity_turns >= 10) {
-		    // Call back Rufus and collect reward
-		    fulfill_quest();
-		    collect_reward(rift);
-
-		    // Accept a new quest
-		    accept_quest();
-
-		    // Adventure!
-		    prepare_for_combat();
-		    fulfill_quest(rift);
-
-		    affinity_turns = have_effect(SHADOW_AFFINITY);
-		}
-	    }
-
-	    // We may still have turns of Shadow Affinity to consume
-	    while (affinity_turns-- > 0) {
-		adventure_once(rift);
-	    }
-	}
-
 	// Fulfill the quest with Rufus
 	fulfill_quest();
 
 	// Adventure once more to collect your reward
 	collect_reward(rift);
+    }
+
+    boolean have_enough_affinity_for_quest(int affinity_turns)
+    {
+	// Given a particular number of turns of Shadow Affinity, do we
+	// have enough to do a quest?
+
+	// If we are buying items, it takes no turns and burns no Shadow
+	// Affinity. If we are not buying items, we cannot predict how
+	// long it will take, since it depends on item drop.
+	//
+	// Therefore, don't consider items quests
+	if (quest_goal == "items") {
+	    return false;
+	}
+
+	return affinity_turns >= get_quest_turns();
+    }
+
+    boolean have_enough_affinity_for_quest()
+    {
+	// Consider all currently available turns of Shadow Affinity
+	int affinity_turns = have_effect(SHADOW_AFFINITY);
+	return have_enough_affinity_for_quest(affinity_turns);
+    }
+
+    // Quests may or may not require combat, but in case they do,
+    // save current state so we can restore it when we finish.
+    string current_battle_action = get_property("battleAction");
+    familiar current_familiar = my_familiar();
+    cli_execute( "checkpoint" );
+
+    try {
+	// Execute the desired quest
+	execute_quest();
+
+	// If user wants to use up left over turns of Shadow Affinity,
+	// do more quests and/or adventure in our selected Shadow Rift.
+	if (use_up_shadow_affinity) {
+	    // If we have time to complete a quest, do it.
+	    while (have_enough_affinity_for_quest()) {
+		execute_quest();
+	    }
+
+	    // If we still have turns of Shadow Affinity, adventure.
+	    int affinity_turns = have_effect(SHADOW_AFFINITY);
+	    while (affinity_turns-- > 0) {
+		adventure_once(rift);
+	    }
+	}
     } finally {
 	set_property("battleAction", current_battle_action);
 	use_familiar(current_familiar);

--- a/scripts/ShadowRiftConsult.ash
+++ b/scripts/ShadowRiftConsult.ash
@@ -247,7 +247,7 @@ void main(int initround, monster foe, string page)
 	// skill that makes it miss or skip its first attack, you need
 	// to one-shot it. Fortunately, it has relatively few HP.
 	if (will_block) {
-	    // If our parka scared it, time to negate its resistances
+	    // If we scared it, time to negate its resistances
 	    shun();
 	}
 	slay();

--- a/scripts/ShadowRiftConsult.ash
+++ b/scripts/ShadowRiftConsult.ash
@@ -107,19 +107,30 @@ if ( !combat_item.combat ) {
 // A combat skill which negates foe's physical and elemental resistances
 static skill SILENT_TREATMENT = $skill[ Silent Treatment ];
 
+// A combat skill which forces the next adventure to be an NC
+static skill LAUNCH_SPIKOLODON_SPIKES = $skill[ Launch spikolodon spikes ];
+
 // A passive skill which lets you throw two combat items at once.
 static skill FUNKSLINGING = $skill[ Ambidextrous Funkslinging ];
+
+// A passive skill which forces the first attack against you to miss
+static skill AIR_OF_MYSTERY = $skill[ Air of Mystery ];
 
 // An item which forces you to attack, rather than use skills, spells, and items.
 static item DRUNKULA = $item[ Drunkula's wineglass ];
 
+// An item which blocks the monster's first attack
+static item PARKA = $item[ Jurassic Parka ];
+
 void main(int initround, monster foe, string page)
 {
-    boolean must_attack = have_equipped( DRUNKULA );
+    boolean must_attack = have_equipped(DRUNKULA);
+    boolean will_block = have_equipped(PARKA) || have_skill(AIR_OF_MYSTERY);
     boolean no_attack = ( foe == $monster[ shadow matrix ] );
     boolean no_combat_spells = ( foe == $monster[ shadow orrery ] );
     boolean can_funksling = have_skill(FUNKSLINGING);
     boolean have_silent_treatment = have_skill(SILENT_TREATMENT);
+    boolean have_spikes = have_skill(LAUNCH_SPIKOLODON_SPIKES);
 
     // Mundane shadow monsters are worth pickpocketing
     void pickpocket()
@@ -136,6 +147,30 @@ void main(int initround, monster foe, string page)
     {
 	if ( !must_attack && have_silent_treatment ) {
 	    page = use_skill( SILENT_TREATMENT );
+	}
+    }
+
+    // If we want to force the next adventure to be an NC - the
+    // Labyrinth of Shadows or a shadow boss - launch spikes at this
+    // one.
+
+    void spikes()
+    {
+	if (have_spikes) {
+	    int turns_until_choice = get_property("encountersUntilSRChoice").to_int();
+	    // Since the counter is not decremented until AFTER this combat is done,
+	    // a value of 1 means the NC is next turn and does not need to be forced.
+	    if (turns_until_choice > 1) {
+		page = use_skill( LAUNCH_SPIKOLODON_SPIKES );
+		// You pull a ripcord on your parka. The spikolodon spikes both fly
+		// into your opponent for 35 damage and ricochet around the area,
+		// scaring away all the other fauna.
+		if (page.contains_text("The spikolodon spikes both fly")) {
+		    // The counter decrements after this combat.
+		    // This will make it 0 for the next adventure.
+		    set_property("encountersUntilSRChoice", "1");
+		}
+	    }
 	}
     }
 
@@ -202,6 +237,8 @@ void main(int initround, monster foe, string page)
 	// to steal, since the monsters are not especially dangerous.
 	pickpocket();
 	shun();
+	// Only force an NC for a regular shadow monster
+	spikes();
 	slay();
 	return;
     case $monster[ shadow scythe ]:
@@ -209,6 +246,10 @@ void main(int initround, monster foe, string page)
 	// always gets the drop, unless you have equipment or a passive
 	// skill that makes it miss or skip its first attack, you need
 	// to one-shot it. Fortunately, it has relatively few HP.
+	if (will_block) {
+	    // If our parka scared it, time to negate its resistances
+	    shun();
+	}
 	slay();
 	return;
     case $monster[ shadow orrery ]:


### PR DESCRIPTION
A Jurassic Parka is interesting for several reasons

1) The first attack against you always misses. This gives you an extra round against a shadow scythe or shadow spire and basically makes all fights safer.
2) In spikolodon mode, you can force the next adventure to be an NC. Which is to say, the Labyrinth of Shadows or a shadow boss. You can do this 5 times a day. That means that 11 turns of Shadow Affinity let you fulfill 5 artifact or entity quests, with either 1 or 6 turns of Shadow Affinity left over.
```
Accept an artifact quest (gain 11 Shadow Affinity)
Fight a normal shadow monster, launch spikolodon spikes, finish combat (1 turn of Shadow Affinity used)
Get artifact from Labyrinth of Shadows (no Shadow Affinity Used)
Get lodestone from Rufus and get reward
(repeat 4 times)
```
5 normal shadow monsters (item drops) + 150 turns of Shadow Waters + 6 turns of Shadow Affinity to burn on 6 normal shadow monsters.
```
Accept an entity quest (gain 11 Shadow Affinity)
Fight a normal shadow monster, launch spikolodon spikes, finish combat (1 turn of Shadow Affinity used)
Fight shadow boss (1 turn of Shadow Affinity used)
Get lodestone from Rufus and get reward
(repeat 4 times)
```
5 normal shadow monsters (item drops) + 5 shadow bosses (2 guaranteed items each) + 150 turns of Shadow Waters + 1 turn of Shadow Affinity to burn on a normal shadow monster

In both scenarios, 11 combats, but, as always, entity goal is more profitable.

I tested today like this:
```
encountersUntilSRChoice = 1
ShadowRift check
ShadowRift items brick forest onlyfree notallfree
(11 + 5 = 16 turns of affinity, using PYEC)
ShadowRift entity random waters onlyfree notallfree
(burning affinity yesterday left the NC 1 turn away, so no spikes needed or used)
(monster + boss -> 16 - 2 = 14 turns of affinity)
ShadowRift entity random waters onlyfree notallfree
(monster spikes + boss  -> 14 - 2 = 12 turns of affinity)
ShadowRift entity random waters onlyfree notallfree
(monster spikes + boss -> 12 - 2 = 10 turns of affinity)
ShadowRift entity random waters onlyfree allfree
(monster spikes + boss -> 10 - 2 = 8 turns of affinity)
(monster spikes + boss -> 8 - 2 = 6 turns of affinity)
(monster spikes + boss -> 6 -2 = 4 turns of affinity)
(monster -> 4 - 1 = 3 turns of affinity)
(monster -> 3 - 1 = 2 turns of affinity)
(monster -> 2 - 1 = 1 turns of affinity)
(monster -> 1 - 1 = 0 turns of affinity)

10 monsters, 6 bosses -> 16 free fights
180 turns of Shadow Waters -> +100 Items +100 Meat +100 Init
3 items spent, 28 items farmed -> net gain 25 items in 0 turns.
encountersUntilSEChoice = 6
```

This PR addresses Issue https://github.com/Veracity0/shadow-rift/issues/24

Things to come - after I get back from my three week vacation starting tomorrow, where I will not be coding:

1) I need to say something more about this in README.md than simply mentioning the new configuration property.

2) I have to think more about whether  having extra Shadow Affinity from a PYEC is better to use before or after. Using it after gives you a head start for tomorrow - and will the carry-over quest progress allow a quest to be fullfilled before you start spiking and forcing NCs? Mayyyyybe. If so I should figure out how to manage that.

